### PR TITLE
use ctx.BlockTime() in favour of time.Now()

### DIFF
--- a/x/interquery/keeper/msg_server_send_query_all_balances.go
+++ b/x/interquery/keeper/msg_server_send_query_all_balances.go
@@ -35,7 +35,7 @@ func (k msgServer) SendQueryAllBalances(goCtx context.Context, msg *types.MsgSen
 
 	// timeoutTimestamp set to max value with the unsigned bit shifted to sastisfy hermes timestamp conversion
 	// it is the responsibility of the auth module developer to ensure an appropriate timeout timestamp
-	timeoutTimestamp := time.Now().Add(time.Minute).UnixNano()
+	timeoutTimestamp := ctx.BlockTime().Add(time.Minute).UnixNano()
 	seq, err := k.SendQuery(ctx, types.PortID, msg.ChannelId, chanCap, reqs, clienttypes.ZeroHeight(), uint64(timeoutTimestamp))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
inspired from https://github.com/cosmos/interchain-accounts-demo/pull/108